### PR TITLE
Unique constraints on dimension tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ pip install -r requirements.txt
     - `docker system prune -a` to delete all *stopped* images and containers
 
 ### Populate Database
-Now that the database instance is up and the schema is created, it needs to be populated with data
-as well as measurements.
+Now that the database instance and the schema are created, the db needs to be populated
 - `python db/db.py` populates all tables with data, including measurements
 
 <!-- ## Docker containers

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ pip install -r requirements.txt
     - `docker compose down` to stop your running containers
     - `docker system prune -a` to delete all *stopped* images and containers
 
+### Populate Database
+Now that the database instance is up and the schema is created, it needs to be populated with data
+as well as measurements.
+- `python db/db.py` populates all tables with data, including measurements
+
 <!-- ## Docker containers
 - Enter `postgres` container
     - `docker exec -it postgres bash` to enter the postgres container

--- a/db/init/schema.sql
+++ b/db/init/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE job_posting_dim (
     minimum_experience INT,
     maximum_experience INT,
     work_type TEXT,
-    gender_preference TEXT
+    gender_preference TEXT,
+    CONSTRAINT unique_job UNIQUE (job_id)
 );
 
 -- Company Profile Dimension
@@ -48,7 +49,8 @@ CREATE TABLE job_posting_date_dim (
     job_posting_date_key SERIAL PRIMARY KEY,
     day INT,
     month INT,
-    year INT
+    year INT,
+    CONSTRAINT unique_date UNIQUE (day, month, year)
 );
 
 -- Benefits Dimension
@@ -65,7 +67,13 @@ CREATE TABLE benefits_dim (
     health_and_wellness_facilities BOOLEAN,
     employee_referral_program BOOLEAN,
     transportation_benefits BOOLEAN,
-    bonuses_and_incentive_programs BOOLEAN
+    bonuses_and_incentive_programs BOOLEAN,
+    CONSTRAINT unique_benefits UNIQUE (
+        retirement_plans, stock_options_or_equity_grants, parental_leave, paid_time_off, 
+        flexible_work_arrangements, health_insurance, life_and_disability_insurance, 
+        employee_assistance_program, health_and_wellness_facilities, employee_referral_program, 
+        transportation_benefits, bonuses_and_incentive_programs
+    )
 );
 
 -- Company HQ Location Dimension


### PR DESCRIPTION
Some dimension tables did not have completely unique values. For instance, the date dimension table has 100,000+ rows. In reality, it should only have a maximum of 365 * 3 years of rows because there are only 3 years' worth of job postings.

This PR fixes that.